### PR TITLE
fixes #42 - Add a startsWith check to publish-new-release workflow

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -11,8 +11,10 @@ jobs:
   release:
     name: Publish new release
     runs-on: ubuntu-latest
-    # only merged pull requests that begin with 'release/' must trigger this job
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    # only merged pull requests that begin with 'release/' or 'hotfix/' must trigger this job
+    if: github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+
     steps:
       - name: Extract version from branch name (for release branches)
         if: startsWith(github.event.pull_request.head.ref, 'release/')

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -11,7 +11,8 @@ jobs:
   release:
     name: Publish new release
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true # only merged pull requests must trigger this job
+    # only merged pull requests that begin with 'release/' must trigger this job
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - name: Extract version from branch name (for release branches)
         if: startsWith(github.event.pull_request.head.ref, 'release/')


### PR DESCRIPTION
fixes #42 - Add a `startsWith` check that verifies the PR being merged in is from a `release/<version>` branch, skipping the workflow if it is not. This saves us from showing failed workflows for non-release PR merges.
 
 Example of this logic skipping non-release PR merges: https://github.com/jsoberg/Loot-Hoard-DnD-Discord-Bot/actions/runs/2988351427
 Example of this logic triggering on release PR merges: https://github.com/jsoberg/Loot-Hoard-DnD-Discord-Bot/actions/runs/2988387989